### PR TITLE
Fix AMD64 get_syscall_arg()

### DIFF
--- a/ministrace.c
+++ b/ministrace.c
@@ -60,7 +60,7 @@ long get_syscall_arg(pid_t child, int which) {
     case 0: return get_reg(child, rdi);
     case 1: return get_reg(child, rsi);
     case 2: return get_reg(child, rdx);
-    case 3: return get_reg(child, rcx);
+    case 3: return get_reg(child, r10);
     case 4: return get_reg(child, r8);
     case 5: return get_reg(child, r9);
 #else


### PR DESCRIPTION
Accoriding to syscall(2) the fourth syscall parameter is passed in
r10 and not rcx. This causes strange behavior when attempting to
trace calls like linkat().

For $ ./ministrace ln ministrace link

Fourth parameter read from r10
linkat(-100, "ministrace", -100, "link", 0) = 0

Fourth parameter read from rcx
linkat(-100, "ministrace", -100, "", 0) = 0
